### PR TITLE
Added parent pom workaround (eclipse-pass-parent/0.0.1-SNAPSHOT)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ jobs:
       - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
       - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
 
+  call-workaround:
+    name: Run Parent POM Workaround
+    uses: eclipse-pass/pass-authz/.github/workflows/parent-pom-workaround.yml@main
+
   call-tests-unit:
     name: Run Unit Tests
     uses: eclipse-pass/pass-authz/.github/workflows/tests-unit.yml@main
+
+#  call-tests-integration:
+#    name: Run Integration Tests
+#    uses: eclipse-pass/pass-authz/.github/workflows/tests-integration.yml@main
+#    needs: call-workaround

--- a/.github/workflows/parent-pom-workaround.yml
+++ b/.github/workflows/parent-pom-workaround.yml
@@ -1,0 +1,24 @@
+name: Parent POM Workaround
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Parent POM Workaround: Checkout pass 'main'"
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-pass/main
+      - name: "Set up JDK 14"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: "Cache Maven packages"
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: "Parent POM Workaround: Install from pass 'main'"
+        run: mvn install --file pom.xml


### PR DESCRIPTION
Added workaround that'll be needed until `eclipse-pass-parent/0.0.1-SNAPSHOT` is published.