### PR TITLE
Add workaround to force Java 11 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,6 @@ jobs:
       - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
       - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
 
-  pom-workaround:
-    name: "Parent POM Workaround"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Parent POM Workaround: Checkout pass 'main'"
-        uses: actions/checkout@v2
-        with:
-          repository: eclipse-pass/main
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: "Cache Maven packages"
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m3-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m3
-      - name: "Parent POM Workaround: Install from pass 'main'"
-        run: mvn install --file pom.xml
-
   run-tests:
     name: "Run Unit & Integration Tests"
     needs: pom-workaround
@@ -47,12 +26,12 @@ jobs:
       - name: "Set up JDK 8"
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: "Cache Maven packages"
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m3-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m3          
+          key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-mvn
       - name: "Run unit and integration tests"
-        run: mvn verify --file pom.xml
+        run: mvn -V -ntp verify --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
 
   run-tests:
     name: "Run Unit & Integration Tests"
-    needs: pom-workaround
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the repository"

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <argLine>
+              --illegal-access=permit
+              --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+            </argLine>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -337,5 +337,16 @@
     <url>https://github.com/eclipse-pass/pass-authz</url>
     <tag>HEAD</tag>
   </scm>
+  
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
 </project>


### PR DESCRIPTION
* Add a compiler argument to the test runner to ignore illegal access exceptions
  * The `powermock` library used in some tests in this repository seems to have never been updated to support Java 11 properly. This workaround explicitly ignores the new exceptions.